### PR TITLE
feat: implement D1 upsert

### DIFF
--- a/d1.js
+++ b/d1.js
@@ -458,6 +458,119 @@ export class D1 {
     return { id: id, response: r, object: ob }
   }
 
+
+  async _upsertp(table, obj, opts = {}) {
+    if (typeof table != 'string') {
+      opts.model = table
+    }
+    let ob = null
+    let fields = []
+    let values = []
+    if (obj instanceof Object && !Array.isArray(obj)) {
+      ob = obj
+      values = []
+      let f2 = []
+      for (const f in obj) {
+        f2.push(f)
+        values.push(obj[f])
+      }
+      fields = f2
+    } else {
+      // deprecated
+      fields = obj
+      values = opts
+      ob = {}
+      opts = {}
+    }
+    let id
+    if (!fields.includes('id')) {
+      id = nanoid()
+      fields.push('id')
+      values.push(id)
+      ob.id = id
+    } else {
+      id = values[fields.indexOf('id')]
+      if (!id) {
+        id = nanoid()
+        values[fields.indexOf('id')] = id
+        ob.id = id
+      }
+    }
+    let now = new Date()
+    if (!fields.includes('createdAt')) {
+      fields.push('createdAt')
+      values.push(now)
+      ob.createdAt = now
+    }
+    if (!fields.includes('updatedAt')) {
+      fields.push('updatedAt')
+      values.push(now)
+      ob.updatedAt = now
+    } else {
+      // If updating, we should probably set updatedAt to now anyway, or keep what they provided?
+      // Let's keep what they provided for consistency with insert, but typically upsert would update the date.
+      // Actually we'll let ON CONFLICT handle updating it to `excluded.updatedAt`.
+    }
+    for (let f of fields) {
+      if (!/^[a-zA-Z0-9]+$/.test(f)) {
+        throw new Error('Field must be alphanumeric')
+      }
+    }
+
+    let tableName = this.tableName(table)
+    let s = `INSERT INTO ${tableName} (${fields.join(', ')}) VALUES (${fields.map((f) => '?').join(',')})`
+
+    let updates = []
+    for (let i = 0; i < fields.length; i++) {
+      let f = fields[i]
+      if (f === 'id' || f === 'createdAt') continue; // Don't update id or createdAt on conflict
+      let v = values[i]
+      if (this.isObject(v)) {
+        updates.push(`${f} = json_patch(COALESCE(${tableName}.${f}, '{}'), excluded.${f})`)
+      } else {
+        updates.push(`${f} = excluded.${f}`)
+      }
+    }
+
+    if (updates.length > 0) {
+      s += ` ON CONFLICT(id) DO UPDATE SET ${updates.join(', ')}`
+    } else {
+      s += ` ON CONFLICT(id) DO NOTHING`
+    }
+
+    if (this.debug) console.log('SQL:', s, values)
+    return { id: id, stmt: this.db.prepare(s).bind(...this.toValues(values)), object: ob }
+  }
+
+  /**
+   * Prepare upsert a record.
+   *
+   * @param {*} table
+   * @param {*} obj the object to store.
+   * @param {*} opts
+   * @returns
+   */
+  async upsertp(table, obj, opts = {}) {
+    let r = await this._upsertp(table, obj, opts)
+    return r.stmt
+  }
+
+  /**
+   * Upsert a record.
+   *
+   * @param {*} table
+   * @param {*} obj the object to store.
+   * @param {*} opts
+   * @returns
+   */
+  async upsert(table, obj, opts = {}) {
+    let { id, stmt: st, object: ob } = await this._upsertp(table, obj, opts)
+    let r = await this.retry(async () => {
+      return await st.run()
+    })
+    return { id: id, response: r, object: ob }
+  }
+
   async _updatep(table, id, obj, opts = {}) {
     if (typeof table != 'string') {
       opts.model = table

--- a/functions/v1/users/upsert.js
+++ b/functions/v1/users/upsert.js
@@ -1,0 +1,8 @@
+import { User } from '../../data/users.js'
+
+export async function onRequestPost(c) {
+  let input = await c.request.json()
+  let user = input.user
+  let r = await c.data.d1.upsert(User, user)
+  return Response.json({ user: r.object })
+}

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ import { testJoinJson } from './test_join_json.js'
 import { testOr } from './test_or.js'
 import { testBatch } from './test_batch.js'
 import { testPatch } from './test_patch.js'
+import { testUpsert } from './test_upsert.js'
 
 // Create the context for your tests, include anything they need to run
 let apiURL = 'http://localhost:8787'
@@ -34,5 +35,6 @@ let testKit = new TestKit(c, [
   testOr,
   testBatch,
   testPatch,
+  testUpsert,
 ])
 await testKit.run()

--- a/test/test_upsert.js
+++ b/test/test_upsert.js
@@ -1,0 +1,46 @@
+import { assert } from 'testkit'
+
+export async function testUpsert(c) {
+  let { api } = c
+  // Clean up
+  await api.fetch('/v1/users/query', {
+    method: 'POST',
+    body: { query: 'delete from users' },
+  })
+
+  // Upsert a new user
+  let user = {
+    id: 'u1',
+    name: 'Alice',
+    email: 'alice@example.com',
+    data: { foo: 'bar' }
+  }
+
+  let r = await api.fetch('/v1/users/upsert', {
+    method: 'POST',
+    body: { user }
+  })
+  assert(r.user, 'Expected user back')
+  assert(r.user.id === 'u1', 'Expected id u1')
+  assert(r.user.name === 'Alice', 'Expected name Alice')
+
+  // Upsert the same user with updated fields
+  let userUpdate = {
+    id: 'u1',
+    name: 'Alice Updated',
+    data: { baz: 'qux' }
+  }
+
+  let r2 = await api.fetch('/v1/users/upsert', {
+    method: 'POST',
+    body: { user: userUpdate }
+  })
+  assert(r2.user, 'Expected user back')
+
+  // Fetch to check
+  let r3 = await api.fetch('/v1/users/u1')
+  assert(r3.user.name === 'Alice Updated', 'Expected name to update')
+  assert(r3.user.email === 'alice@example.com', 'Expected email to remain unchanged')
+  assert(r3.user.data.foo === 'bar', 'Expected json_patch to merge object, keeping foo')
+  assert(r3.user.data.baz === 'qux', 'Expected json_patch to merge object, adding baz')
+}


### PR DESCRIPTION
Adds `upsert` and `upsertp` methods to `D1` in `d1.js` leveraging SQLite's `INSERT ... ON CONFLICT(id) DO UPDATE SET ...` syntax. Properly merges object properties via `json_patch`. Also adds a test file (`test_upsert.js`) to verify functionality.

---
*PR created automatically by Jules for task [5877242264351571818](https://jules.google.com/task/5877242264351571818) started by @treeder*